### PR TITLE
Adding an argument to offer the user to not start rviz on launch

### DIFF
--- a/dsr_description/launch/m1013.launch
+++ b/dsr_description/launch/m1013.launch
@@ -8,6 +8,7 @@
     <arg name="remap"   default="False"/>
     <arg name="color"   default="white"/>
     <arg name="gripper" default="none"/>
+    <arg name="rviz"    default="True"/>
 
     <param name="robot_description" command="$(find xacro)/xacro '$(find dsr_description)/xacro/$(arg model).urdf.xacro' '--inorder' 'namespace:=$(arg ns)' color:=$(arg color) gripper:=$(arg gripper)"/>
 .
@@ -29,5 +30,5 @@
     </group>
 
     <!-- Show in Rviz -->
-    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find dsr_description)/rviz/default.rviz"/>
+    <node if="$(arg rviz)" name="rviz" pkg="rviz" type="rviz" args="-d $(find dsr_description)/rviz/default.rviz"/>
 </launch>


### PR DESCRIPTION
We are running our own rviz, and would like to use <include> and the m1013.launch file. It would therefore be convenient to control this with an arg. 