### PR TITLE
Setting safety mode on start RT control

### DIFF
--- a/dsr_control/src/dsr_hw_interface.cpp
+++ b/dsr_control/src/dsr_hw_interface.cpp
@@ -3043,6 +3043,11 @@ namespace dsr_control{
     {
         res.success = false;
         res.success = Drfl.start_rt_control();
+        if(!res.success) {
+            return false;
+        }
+        res.success = Drfl.set_safety_mode(SAFETY_MODE_AUTONOMOUS,
+                                 SAFETY_MODE_EVENT_MOVE);
         return true;
     }
 


### PR DESCRIPTION
Setting the safety mode  to `SAFETY_MODE_EVENT_MOVE` when starting RT control according to *main.cpp* in the examples of the API. Otherwise the robot does not move on `servoj_rt` or `speedj_rt` commands and communication issues may occur.