### PR TITLE
Adding common include directory to Catkin package

### DIFF
--- a/dsr_control/CMakeLists.txt
+++ b/dsr_control/CMakeLists.txt
@@ -9,10 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
   serial
   roscpp
 )
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS dsr_msgs controller_manager hardware_interface roscpp serial
-)
 
 SET( COMMON_INC_FILES
   #../../../common/include
@@ -24,6 +20,11 @@ SET( COMMON_LIB_FILES
 
 SET( SERIAL_SRC_FILES
   ../common/src/dsr_serial.cpp
+)
+catkin_package(
+  INCLUDE_DIRS include ${COMMON_INC_FILES}
+  LIBRARIES dsr_control
+  CATKIN_DEPENDS dsr_msgs controller_manager hardware_interface roscpp serial
 )
 
 
@@ -64,7 +65,34 @@ target_link_libraries(dsr_control_node ${catkin_LIBRARIES})
 target_link_libraries(dsr_control_node DRFL PocoFoundation PocoNet)
 
 
+
 install(TARGETS dsr_control_node
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+add_library(dsr_control
+  ${SERIAL_SRC_FILES}
+  src/dsr_hw_interface.cpp
+)
+
+target_include_directories(dsr_control
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common/include
+)
+
+target_link_libraries(dsr_control 
+  PUBLIC
+    DRFL 
+    PocoFoundation 
+    PocoNet
+    ${catkin_LIBRARIES} 
+)
+
+
+install(TARGETS dsr_control
    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -73,3 +101,4 @@ install(TARGETS dsr_control_node
 install(DIRECTORY config launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+


### PR DESCRIPTION
Moving `catkin_package` macro and adding variable of common include directories to enable usage of the dsr_control library outside the *dsr_control* package.