### PR TITLE
fix: close tag while loading a param

### DIFF
--- a/dsr_control/launch/dsr_moveit.launch
+++ b/dsr_control/launch/dsr_moveit.launch
@@ -22,7 +22,7 @@
     <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
           output="screen" ns="$(arg ns)$(arg model)" args="dsr_joint_publisher"/>
 
-    <param name="$(arg ns)$(arg model)/move_group/trajectory_execution/execution_duration_monitoring" value="false">
+    <param name="$(arg ns)$(arg model)/move_group/trajectory_execution/execution_duration_monitoring" value="false" />
     <!-- moveit은 멀티 arm이 안되므로 model은 참조용으로 사용 -->
     <node pkg="dsr_control" type="dsr_control_node" name="$(arg ns)$(arg model)" respawn="false" output="screen" >
         <param name="name" value="$(arg ns)"/>


### PR DESCRIPTION
Executing [dsr_moveit.launch](https://github.com/doosan-robotics/doosan-robot/blob/noetic-devel/dsr_control/launch/dsr_moveit.launch) fails while loading [`move_group/trajectory_execution/execution_duration_monitoring`](https://github.com/doosan-robotics/doosan-robot/blob/noetic-devel/dsr_control/launch/dsr_moveit.launch#L25) param.

### Reproducing the issue:
It can be reproduced by launching the above launch file.
```
roslaunch dsr_control dsr_moveit.launch
```

### Propose
It can be solved by just closing the tag as the following:
```diff
- <param name="$(arg ns)$(arg model)/move_group/trajectory_execution/execution_duration_monitoring" value="false">
+ <param name="$(arg ns)$(arg model)/move_group/trajectory_execution/execution_duration_monitoring" value="false" />
```

### Misc
The same issue persists in other branches