### PR TITLE
Clarify ROS1 support status and redirect to ROS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## ⚠️ ROS1 support ended in **May 2025** with the official termination of ROS1. <br>
+### 👉 Please use the https://github.com/DoosanRobotics/doosan-robot2
+
 
 # [Doosan Robotics](http://www.doosanrobotics.com/kr/)
 [![license - apache 2.0](https://img.shields.io/:license-Apache%202.0-yellowgreen.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -5,7 +8,7 @@
 [![support level: community](https://img.shields.io/badge/support%20level-community-lightgray.png)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
 
 # *overview*
-##### :exclamation: ROS1 support will terminate in May 2025 with the end of official ROS1. Please use the [Doosan ROS2 package](https://github.com/DoosanRobotics/doosan-robot2).
+
 
 [Doosan ROS Video](https://www.youtube.com/watch?v=mE24X5PhZ4M&feature=youtu.be)   
 <img src="https://user-images.githubusercontent.com/47092672/113229859-c1f86100-92d2-11eb-8242-3aa7e7f7ef88.png" width="50%">  


### PR DESCRIPTION
Updated README to clarify ROS1 support termination and redirect to ROS2 package.